### PR TITLE
plasma-window: add client geometry + bump to v18

### DIFF
--- a/src/protocols/plasma-window-management.xml
+++ b/src/protocols/plasma-window-management.xml
@@ -6,7 +6,7 @@
     SPDX-License-Identifier: LGPL-2.1-or-later
   ]]></copyright>
 
-  <interface name="org_kde_plasma_window_management" version="17">
+  <interface name="org_kde_plasma_window_management" version="18">
     <description summary="application windows management">
       This interface manages application windows.
       It provides requests to show and hide the desktop and emits
@@ -116,7 +116,7 @@
     </request>
   </interface>
 
-  <interface name="org_kde_plasma_window" version="17">
+  <interface name="org_kde_plasma_window" version="18">
     <description summary="interface to control application windows">
       Manages and control an application window.
 
@@ -394,6 +394,17 @@
         This is only set for XWayland windows.
       </description>
       <arg name="resource_name" type="string" summary="resource name"/>
+    </event>
+
+    <event name="client_geometry" since="18">
+        <description summary="The client geometry (i.e. without decorations etc) of this window in absolute coordinates">
+            This event will be sent whenever the window geometry of this org_kde_plasma_window changes.
+            The coordinates are in absolute coordinates of the windowing system.
+        </description>
+        <arg name="x" type="int" summary="x position of the org_kde_plasma_window"/>
+        <arg name="y" type="int" summary="y position of the org_kde_plasma_window"/>
+        <arg name="width" type="uint" summary="width of the org_kde_plasma_window"/>
+        <arg name="height" type="uint" summary="height of the org_kde_plasma_window"/>
     </event>
   </interface>
 


### PR DESCRIPTION
this will allow us to retrieve the window
coordinates without decoration (this is handy when translating between global coordinates and in-window coordinates).

this allows implementing better coordinate-based click support in selenium-at-spi